### PR TITLE
Created commands as services to remove deprecation warnings from Symfony 4.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 /vendor/
+.idea

--- a/Command/AbstractCronCommand.php
+++ b/Command/AbstractCronCommand.php
@@ -2,7 +2,7 @@
 
 namespace MadrakIO\EasyCronDeploymentBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
@@ -11,7 +11,7 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-abstract class AbstractCronCommand extends ContainerAwareCommand
+abstract class AbstractCronCommand extends Command
 {
     protected function jobArrayToCrontabLine(array $job, $includeNewLine = true)
     {

--- a/Command/CronDeployCommand.php
+++ b/Command/CronDeployCommand.php
@@ -5,11 +5,24 @@ namespace MadrakIO\EasyCronDeploymentBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use MadrakIO\EasyCronDeploymentBundle\Command\AbstractCronCommand;
-
 
 class CronDeployCommand extends AbstractCronCommand
 {
+    /**
+     * @var array
+     */
+    private $jobs;
+
+    /**
+     * @param array $jobs
+     */
+    public function __construct(array $jobs)
+    {
+        parent::__construct();
+
+        $this->jobs = $jobs;
+    }
+
     protected function configure()
     {
         $this
@@ -29,7 +42,7 @@ class CronDeployCommand extends AbstractCronCommand
         $this->interactiveOperationConfirmation($input, $output);
 
         $cronFileContents = '';
-        foreach ($this->getContainer()->getParameter('madrak_io_easy_cron_deployment.jobs') AS $job) {
+        foreach ($this->jobs as $job) {
             if ($this->checkJobHasMatchingHostRequirement($job) === true) {
                 $cronFileContents .= $this->jobArrayToCrontabLine($job);
             }

--- a/Command/CronDisableCommand.php
+++ b/Command/CronDisableCommand.php
@@ -5,7 +5,6 @@ namespace MadrakIO\EasyCronDeploymentBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use MadrakIO\EasyCronDeploymentBundle\Command\AbstractCronCommand;
 
 class CronDisableCommand extends AbstractCronCommand
 {

--- a/Command/CronEnableCommand.php
+++ b/Command/CronEnableCommand.php
@@ -5,7 +5,6 @@ namespace MadrakIO\EasyCronDeploymentBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use MadrakIO\EasyCronDeploymentBundle\Command\AbstractCronCommand;
 
 class CronEnableCommand extends AbstractCronCommand
 {

--- a/Command/CronVerifyCommand.php
+++ b/Command/CronVerifyCommand.php
@@ -5,10 +5,24 @@ namespace MadrakIO\EasyCronDeploymentBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use MadrakIO\EasyCronDeploymentBundle\Command\AbstractCronCommand;
 
 class CronVerifyCommand extends AbstractCronCommand
 {
+    /**
+     * @var array
+     */
+    private $jobs;
+
+    /**
+     * @param array $jobs
+     */
+    public function __construct(array $jobs)
+    {
+        parent::__construct();
+
+        $this->jobs = $jobs;
+    }
+
     protected function configure()
     {
         $this
@@ -31,7 +45,7 @@ class CronVerifyCommand extends AbstractCronCommand
         }
         
         $expectedTasks = [];
-        foreach ($this->getContainer()->getParameter('madrak_io_easy_cron_deployment.jobs') AS $job) {
+        foreach ($this->jobs as $job) {
             if ($this->checkJobHasMatchingHostRequirement($job) === true) {
                 $expectedTasks[] = $this->jobArrayToCrontabLine($job, false);                
             }

--- a/DependencyInjection/MadrakIOEasyCronDeploymentExtension.php
+++ b/DependencyInjection/MadrakIOEasyCronDeploymentExtension.php
@@ -4,8 +4,8 @@ namespace MadrakIO\EasyCronDeploymentBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use Symfony\Component\DependencyInjection\Loader;
 
 /**
  * This is the class that loads and manages your bundle configuration.
@@ -16,6 +16,8 @@ class MadrakIOEasyCronDeploymentExtension extends Extension
 {
     /**
      * {@inheritdoc}
+     *
+     * @throws \Exception
      */
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -24,6 +26,12 @@ class MadrakIOEasyCronDeploymentExtension extends Extension
 
         foreach ($config AS $configKey => $configValue) {
             $container->setParameter('madrak_io_easy_cron_deployment.' . $configKey, $configValue);
-        }                
+        }
+
+        $loader = new YamlFileLoader(
+            $container,
+            new FileLocator(__DIR__.'/../Resources/config')
+        );
+        $loader->load('services.yml');
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,0 +1,24 @@
+services:
+    madrak_io_easy_cron_deployment.deploy_command:
+        class: 'MadrakIO\EasyCronDeploymentBundle\Command\CronDeployCommand'
+        arguments:
+            - '%madrak_io_easy_cron_deployment.jobs%'
+        tags:
+            - { name: console.command }
+
+    madrak_io_easy_cron_deployment.disable_command:
+        class: 'MadrakIO\EasyCronDeploymentBundle\Command\CronDisableCommand'
+        tags:
+            - { name: console.command }
+
+    madrak_io_easy_cron_deployment.enable_command:
+        class: 'MadrakIO\EasyCronDeploymentBundle\Command\CronEnableCommand'
+        tags:
+            - { name: console.command }
+
+    madrak_io_easy_cron_deployment.verify_command:
+        class: 'MadrakIO\EasyCronDeploymentBundle\Command\CronVerifyCommand'
+        arguments:
+            - '%madrak_io_easy_cron_deployment.jobs%'
+        tags:
+            - { name: console.command }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": ">=5.3.9",
+        "php": ">=5.4",
         "symfony/symfony": ">=2.7.0"
     },
     "require-dev": {


### PR DESCRIPTION
Symfony 4.2 deprecated ContainerAwareCommand. This PR fixes deprecation warnings.